### PR TITLE
[SL-1892] | Add PCA authority fallback for Android silent auth

### DIFF
--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -186,9 +186,20 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
             msal.iSingleAccountPca!!.currentAccount?.let { accountResult ->
                 val currentAccount = accountResult.currentAccount
                 if (currentAccount != null) {
+                    val resolvedAuthority: String = when {
+                        // Per-call override (from Dart)
+                        !authority.isNullOrBlank() -> authority
+
+                        // Account authority
+                        currentAccount.authority.isNotBlank() -> currentAccount.authority
+
+                        // Fallback: PCA-level authority set during create*Pca
+                        else -> this.authority
+                    }
+
                     val builder = AcquireTokenSilentParameters.Builder()
                     builder.withScopes(scopes.toList()).forAccount(currentAccount)
-                        .fromAuthority(authority ?: currentAccount.authority)
+                        .fromAuthority(resolvedAuthority)
                         .withCallback(msal.silentAuthenticationCallback(result))
                     val acquireTokenParameters = builder.build()
                     msal.iPublicClientApplication.acquireTokenSilentAsync(acquireTokenParameters)
@@ -198,16 +209,15 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
             }
         } else if (msal.iMultipleAccountPca != null) {
             msal.iMultipleAccountPca!!.getAccount(identifier!!)?.let { account ->
-                // Prefer a valid URL authority from the account; otherwise fall back
-                // to the method parameter, then to the PCA-level authority set at
-                // creation time. This avoids passing null to fromAuthority().
                 val resolvedAuthority: String = when {
-                    Patterns.WEB_URL.matcher(account.authority)
-                        .matches() && account.authority.isNotBlank() -> account.authority
-
+                    // Per-call override (from Dart)
                     !authority.isNullOrBlank() -> authority
 
-                    else -> this.authority  // class field set in create*Pca
+                    // Use account authority only if it looks like a URL
+                    Patterns.WEB_URL.matcher(account.authority).matches() -> account.authority
+
+                    // Fallback: PCA-level authority set during create*Pca
+                    else -> this.authority
                 }
 
                 val builder = AcquireTokenSilentParameters.Builder()

--- a/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
+++ b/android/src/main/kotlin/com/example/msal_auth/MsalAuthHandler.kt
@@ -108,9 +108,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         }
 
         SingleAccountPublicClientApplication.createSingleAccountPublicClientApplication(
-            msal.context,
-            configFile,
-            msal.singleAccountApplicationCreatedListener(result)
+            msal.context, configFile, msal.singleAccountApplicationCreatedListener(result)
         )
     }
 
@@ -127,9 +125,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         }
 
         MultipleAccountPublicClientApplication.createMultipleAccountPublicClientApplication(
-            msal.context,
-            configFile,
-            msal.multipleAccountApplicationCreatedListener(result)
+            msal.context, configFile, msal.multipleAccountApplicationCreatedListener(result)
         )
     }
 
@@ -147,7 +143,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         prompt: Prompt,
         loginHint: String?,
         authority: String?,
-        result: MethodChannel.Result
+        result: MethodChannel.Result,
     ) {
         if (!msal.isPcaInitialized()) {
             setPcaInitError("acquireToken", result)
@@ -156,15 +152,11 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
 
         msal.activity.let {
             val builder = AcquireTokenParameters.Builder()
-            builder.startAuthorizationFromActivity(it)
-                .withScopes(scopes.toList())
-                .withPrompt(prompt)
-                .withLoginHint(loginHint)
-                .apply {
+            builder.startAuthorizationFromActivity(it).withScopes(scopes.toList())
+                .withPrompt(prompt).withLoginHint(loginHint).apply {
                     // If authority is provided, set it to the builder
                     if (authority != null) fromAuthority(authority)
-                }
-                .withCallback(msal.authenticationCallback(result))
+                }.withCallback(msal.authenticationCallback(result))
 
             val acquireTokenParameters = builder.build()
             msal.iPublicClientApplication.acquireToken(acquireTokenParameters)
@@ -183,7 +175,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
         scopes: List<String>,
         identifier: String? = null,
         authority: String?,
-        result: MethodChannel.Result
+        result: MethodChannel.Result,
     ) {
         if (!msal.isPcaInitialized()) {
             setPcaInitError("acquireTokenSilent", result)
@@ -195,8 +187,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
                 val currentAccount = accountResult.currentAccount
                 if (currentAccount != null) {
                     val builder = AcquireTokenSilentParameters.Builder()
-                    builder.withScopes(scopes.toList())
-                        .forAccount(currentAccount)
+                    builder.withScopes(scopes.toList()).forAccount(currentAccount)
                         .fromAuthority(authority ?: currentAccount.authority)
                         .withCallback(msal.silentAuthenticationCallback(result))
                     val acquireTokenParameters = builder.build()
@@ -207,15 +198,21 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
             }
         } else if (msal.iMultipleAccountPca != null) {
             msal.iMultipleAccountPca!!.getAccount(identifier!!)?.let { account ->
-                val authority = if (Patterns.WEB_URL.matcher(account.authority).matches()) {
-                    account.authority
-                } else {
-                    authority
+                // Prefer a valid URL authority from the account; otherwise fall back
+                // to the method parameter, then to the PCA-level authority set at
+                // creation time. This avoids passing null to fromAuthority().
+                val resolvedAuthority: String = when {
+                    Patterns.WEB_URL.matcher(account.authority)
+                        .matches() && account.authority.isNotBlank() -> account.authority
+
+                    !authority.isNullOrBlank() -> authority
+
+                    else -> this.authority  // class field set in create*Pca
                 }
+
                 val builder = AcquireTokenSilentParameters.Builder()
-                builder.withScopes(scopes.toList())
-                    .forAccount(account)
-                    .fromAuthority(authority)
+                builder.withScopes(scopes.toList()).forAccount(account)
+                    .fromAuthority(resolvedAuthority)
                     .withCallback(msal.silentAuthenticationCallback(result))
                 val acquireTokenParameters = builder.build()
                 msal.iPublicClientApplication.acquireTokenSilentAsync(acquireTokenParameters)
@@ -305,9 +302,7 @@ class MsalAuthHandler(private val msal: MsalAuth) : MethodChannel.MethodCallHand
      */
     private fun setPcaInitError(methodName: String, result: MethodChannel.Result) {
         result.error(
-            "PCA_INIT",
-            "PublicClientApplication should be initialized to call $methodName.",
-            null
+            "PCA_INIT", "PublicClientApplication should be initialized to call $methodName.", null
         )
     }
 }


### PR DESCRIPTION
Ensure Android `acquireTokenSilent` always passes a **valid authority**.

- **Multi-account**: fall back to the configured **PCA authority** when the cached account authority is **not a URL** (fixes silent login failures for **invited/guest** tenants)
- **Single-account**: add the same **PCA authority fallback** for future-proofing